### PR TITLE
Ephemeris Time of Day

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,18 @@ The unit tests are also another good place to find usage examples.
 To start this repo will contain Python and Rules DSL rules.
 Over time JavaScript versions of the same rules will be added.
 The ultimate goal is to develop rule templates usable from the OH UI Rules Editor or through the REST API.
+
+# List of libraries
+
+Library | Type | Purpose | Dependencies
+-|-|-|-
+`countdown_timer` | module | Implements a Timer that updates an Item with the number of seconds remaining on the timer every second until the Timer expires. | None
+`debounce` | script | Implements debounce or antiflapping on Items with "debounce" metadata. | `timer_mgr`, `time_utils`
+`deferred` | module | Schedules a command or update to be sent to an Item in the future. |  `timer_mgr`, `time_utils`
+`ephem_tod` | script | Implements the Time of Day design pattern example using Item metadata and Ephemeris. | `timer_mgr`, `time_utils`
+`gatekeeper` | module | Enforces a delay between actions. | None
+`hystersis` | module | A simple function to calculate a hysteresis comparison. | None
+`item_init` | script | Rule that runs at startup or when commanded that initializes the state of Items as defined in the Item's metadata. | None
+`rate_limit` | module | Enforces a timeout where actions that occur inside the timeout are ignored. | None
+`time_utils` | module | Some functions to help parse and convert various representatiosns of time and time durations. | None
+`timer_mgr` | module | Manages a whole collection of Timers with four simple functions. | `time_utils`

--- a/debounce/automation/jsr223/python/community/debounce/debounce.py
+++ b/debounce/automation/jsr223/python/community/debounce/debounce.py
@@ -22,7 +22,7 @@ from core.log import logging, LOG_PREFIX, log_traceback
 from community.time_utils import parse_duration
 from community.timer_mgr import TimerMgr
 
-init_logger = logging.getLogger("{}.Expire Init".format(LOG_PREFIX))
+init_logger = logging.getLogger("{}.Debounce".format(LOG_PREFIX))
 
 timers = TimerMgr()
 
@@ -110,7 +110,7 @@ def debounce(event):
 
     isCommand = True if cfg.configuration["command"] == "True" else False
     proxy = cfg.value
-    states = [st.strip() for st in cfg.configuration["state"].split(",")] if cfg.configuration["state"] else None
+    states = [st.strip() for st in cfg.configuration["state"].split(",")] if "state" in cfg.configuration else None
     timeout = str(cfg.configuration["timeout"])
 
     if not states or (states and str(event.itemState) in states):

--- a/deferred/automation/lib/python/community/deferred.py
+++ b/deferred/automation/lib/python/community/deferred.py
@@ -16,11 +16,7 @@ limitations under the License.
 from core.actions import ScriptExecution
 from core.jsr223.scope import events
 from org.joda.time import DateTime
-import community.time_utils
-reload(community.time_utils)
 from community.time_utils import to_datetime
-import community.timer_mgr
-reload(community.timer_mgr)
 from community.timer_mgr import TimerMgr
 
 timers = TimerMgr()

--- a/ephem_tod/README.md
+++ b/ephem_tod/README.md
@@ -9,11 +9,18 @@ This is adequate for many users, but some users may require a different set of t
 # Requirements
 
 - Ephemeris configured (see https://www.openhab.org/docs/configuration/actions.html#ephemeris)
-- item_init for statically defined times of day
-- timer_mgr to manage the Timers.
-- time_utils to process DateTimeTypes and it's needed by timer_mgr.
+- item_init, optional, used for statically defined times of day
+- timer_mgr to manage the Timers
+- time_utils to process DateTimeTypes and it's needed by timer_mgr
 
 # How it works
+The Rule will create the following two Items if they do not already exist.
+
+Item | Purpose
+-|-
+`CalculateETOD` | Switch Item, when it receives an ON command it will recalulate the time of day.
+`TimeOfDay` | String Item that contains the current time of day. The values are defined with the metadata on the DateTime Items that drive the state machine.
+
 The statemachine is driven by DateTime Items with `etod` metadata defined.
 
 ```
@@ -27,7 +34,7 @@ Argument | Values | Purpose
 `set` | The name of the custom dayset | Only valid when type is `dayset`.
 `file` | Path to Ephemeris XML file | Only valid when type is `custom`, the path to the custom Ephemeris holiday configuration.
 
-Ephemeris provides a number of ways to categorize days, daysets and holidays.
+Ephemeris provides a number of ways to categorize days, daysets, and holidays.
 
 A dayset is a list of the days of the week with a name, for example weekend would include SATURDAY and SUNDAY by default.
 Weekday is a special dayset that is essentially those days not listed as a weekend.
@@ -81,7 +88,8 @@ DateTime Weekend_Day { channel="astro:sun:set120:set#start", etod="DAY"[type="cu
 DateTime Weekend_Evening { channel="astro:sun:local:set#start", etod="EVENING"[type="custom", file="/openhab/conf/services/custom1.xml"] }
 DateTime Default_BEd { init="00:02:00", etod="BED"[type="custom", file="/openhab/conf/services/custom1.xml"] }
 ```
-# Limitations
-Does not handle cases where custom daysets overlap.
 
-Does not handle cases where custom holidays file overlap.
+# Limitations
+- Does not handle cases where custom daysets overlap.
+- Does not handle cases where custom holidays defined in different Ephemeris files overlap.
+- When adding new DateTime Items, the .py file needs to be reloaded to regenerate the triggers.

--- a/ephem_tod/README.md
+++ b/ephem_tod/README.md
@@ -1,0 +1,87 @@
+# Ephemeris Time of Day
+An implementation for the [Time of Day](https://community.openhab.org/t/design-pattern-time-of-day/15407) design pattern shows a way to generate a state machine that tracks the current time of day.
+
+# Purpose
+The Time of Day design pattern implements a state machine that tracks the various time periods throughout the day.
+The day is broken up into contiguous time periods, each of which is defined by a name and start time.
+This is adequate for many users, but some users may require a different set of time periods based on the type of day, e.g. MORNING may start later on weekends and holidays and AFTERNOON may not even exists on weekdays.
+
+# Requirements
+
+- Ephemeris configured (see https://www.openhab.org/docs/configuration/actions.html#ephemeris)
+- item_init for statically defined times of day
+- timer_mgr to manage the Timers.
+- time_utils to process DateTimeTypes and it's needed by timer_mgr.
+
+# How it works
+The statemachine is driven by DateTime Items with `etod` metadata defined.
+
+```
+etod="STATE"[type="daytype", set="dayset", file="uri"]
+```
+
+Argument | Values | Purpose
+-|-|-
+`"STATE"` | The name of the state that starts at the date/time stored in this Item's state. | The String that gets commanded to the TimeOfDay Item which indicates the current timeof day state.
+`type` | The Ephemeris type (see below) | Indicates what sort of day type is defined in Ephemeris, defaults to `default`.
+`set` | The name of the custom dayset | Only valid when type is `dayset`.
+`file` | Path to Ephemeris XML file | Only valid when type is `custom`, the path to the custom Ephemeris holiday configuration.
+
+Ephemeris provides a number of ways to categorize days, daysets and holidays.
+
+A dayset is a list of the days of the week with a name, for example weekend would include SATURDAY and SUNDAY by default.
+Weekday is a special dayset that is essentially those days not listed as a weekend.
+One can define a custom set of daysets (e.g. garabage-day=MONDAY) if desired.
+
+When Ephemeris is configured with a country and region, it loads a default list of "bank holidays" for that region.
+One can additionally define a custom set of holidays by creating an XML file.
+See the docs (link above) for details.
+
+This script supports all of the different ways Ephemeris can define a day through the following `types`.
+
+Type | Purpose
+-|-
+`default` | Used when no other Ephemeris day type is configured.
+`weekday` | Used when Ephemeris indicates that today is a weekday.
+`weekend` | Used when Ephemeris indicates that today is a weekend.
+`dayset` | In addition to weekend, Ephemeris allows the definition of additional daysets (e.g school-day)
+`holiday` | When Ephemeris is configured with a country and region, it loads a standard set of holidays. This Item will be used when today matches the given holiday.
+`custom` | Ephemeris allows the definition of custom holidays
+
+# Examples
+
+```
+// Default day, notice the use of init_items to initialize the state of the Item
+DateTime Default_Morning { init="2020-06-01T06:00:00", etod="MORNING"[type="default"] }
+DateTime Default_Day { channel="astro:sun:set120:set#start", etod="DAY"[type="default"] }
+DateTime Default_Evening { channel="astro:sun:local:set#start", etod="EVENING"[type="default"] }
+DateTime Default_Night { init="23:00:00", etod="NIGHT"[type="default"] }
+DateTime Default_Bed { init="00:02:00", etod="BED"[type="default"] }
+
+// Weekend day, notice that not all the states are listed, the unlisted states are skipped
+DateTime Weekend_Day { channel="astro:sun:set120:set#start", etod="DAY"[type="weekend"] }
+DateTime Weekend_Evening { channel="astro:sun:local:set#start", etod="EVENING"[type="weekend"] }
+DateTime Default_Bed { init="00:02:00", etod="BED"[type="weekend"] }
+
+// Custom dayset
+DateTime Trash_Morning { init="06:00:00", etod="MORNING"[type="dayset", set="trash"] }
+DateTime Trash_Trashtime { init="07:00:00", etod="TRASH"[type="dayset", set="trash"]}
+DateTime Trash_Day { channel="astro:sun:set120:set#start", etod="DAY"[type="dayset", set="trash"] }
+DateTime Trash_Evening { channel="astro:sun:local:set#start", etod="EVENING"[type="dayset", set="trash"] }
+DateTime Trash_Night { init="23:00:00", etod="NIGHT"[type="dayset", set="trash"] }
+DateTime Trash_Bed { init="00:02:00", etod="BED"[type="dayset", set="trash"] }
+
+// Default holiday
+DateTime Weekend_Day { channel="astro:sun:set120:set#start", etod="DAY"[type="holiday"] }
+DateTime Weekend_Evening { channel="astro:sun:local:set#start", etod="EVENING"[type="holiday"] }
+DateTime Default_BEd { init="00:02:00", etod="BED"[type="holiday"] }
+
+// Custom holiday
+DateTime Weekend_Day { channel="astro:sun:set120:set#start", etod="DAY"[type="custom", file="/openhab/conf/services/custom1.xml"] }
+DateTime Weekend_Evening { channel="astro:sun:local:set#start", etod="EVENING"[type="custom", file="/openhab/conf/services/custom1.xml"] }
+DateTime Default_BEd { init="00:02:00", etod="BED"[type="custom", file="/openhab/conf/services/custom1.xml"] }
+```
+# Limitations
+Does not handle cases where custom daysets overlap.
+
+Does not handle cases where custom holidays file overlap.

--- a/ephem_tod/automation/jsr223/python/community/ephem_tod/ephem_tod.py
+++ b/ephem_tod/automation/jsr223/python/community/ephem_tod/ephem_tod.py
@@ -1,0 +1,197 @@
+"""
+Copyright June 30, 2020 Richard Koshak
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from core.rules import rule
+from core.triggers import when
+from core.metadata import get_metadata, get_key_value, get_value
+from core.actions import Ephemeris
+from core.utils import send_command_if_different
+from org.joda.time import DateTime
+import community.time_utils
+reload(community.time_utils)
+from community.time_utils import to_today
+from community.timer_mgr import TimerMgr
+
+# Create an Item to trigger the rule on command if it doesn't exist.
+ETOD_TRIGGER_ITEM = "CalculateETOD"
+if ETOD_TRIGGER_ITEM not in items:
+    from core.items import add_item
+    add_item(ETOD_TRIGGER_ITEM, item_type="Switch")
+
+# Create the time of day state Item if it doesn't exist.
+ETOD_ITEM = "TimeOfDay"
+if ETOD_ITEM not in items:
+    from core.items import add_item
+    add_item(ETOD_ITEM, item_type="String")
+
+# Metadata name space.
+NAMESPACE = "etod"
+
+# Timers that run at time of day transitions.
+timers = TimerMgr()
+
+def get_times(log):
+    """Gets the list of Items that define the start times for today. It uses
+    Ephemeris to determine which set of Items to select. The hierarchy is:
+        - custom: custom defined holidays
+        - holiday: default holidays
+        - dayset: custom defined dayset
+        - weekend: weekend as defined in Ephemeris
+        - weekday: not weekend days
+        - default: used when no other day type is detected for today
+    Arguments:
+        - log: the logger used to log out debug information
+    Returns:
+        - a list of names for DateTime Items; None if no valid start times were
+        found.
+    """
+    def cond(lst, cond):
+        return [i for i in lst if cond(i)]
+
+    def types(type):
+        return [i for i in items if get_key_value(i, NAMESPACE, "type") == type]
+
+    # Get all of the etod Items that are valid for today.
+    start_times = {'default': types("default"),
+                   'weekday': types("weekday") if not Ephemeris.isWeekend() else [],
+                   'weekend': types("weekend") if Ephemeris.isWeekend() else [],
+                   'dayset': cond(types('dayset'),
+                                lambda i: Ephemeris.isInDaySet(get_key_value(i, "set"))),
+                   'holiday': cond(types('holiday'),
+                                lambda i: Ephemeris.isBankHoliday()),
+                   'custom': cond(types('custom'),
+                                lambda i: Ephemeris.isBankHoliday(0, get_key_value(i, NAMESPACE, "file")))}
+
+    # Determins which start time Items to use according to the hierarchy.
+    day_type = None
+    if start_times['custom']:
+        day_type = 'custom'
+    elif start_times['holiday']:
+        day_type = 'holiday'
+    elif start_times['dayset']:
+        day_type = 'dayset'
+    elif start_times['weekend']:
+        day_type = 'weekend'
+    elif start_times['weekday']:
+        day_type = 'weekday'
+    elif start_times['default']:
+        day_type = 'default'
+
+    log.info("Today is a {} day.".format(day_type))
+    return start_times[day_type] if day_type else None
+
+def etod_transition(state, log):
+    """Called from the timers, transitions to the next time of day.
+    Arguments:
+        - state: the state to transition into
+        - log: logger to log debug information
+    """
+    log.info("Transitioning Time of Day from {} to {}"
+             .format(items[ETOD_ITEM], state))
+    events.sendCommand(ETOD_ITEM, state)
+
+def create_timers(start_times, log):
+    """Creates Timers to transition the time of day based on the passed in list
+    of DateTime Item names. If an Item is dated with yesterday, the Item is
+    updated to today. The ETOD_ITEM is commanded to the current time of day if
+    it's not already the correct state.
+    Arguments:
+        - start_times: list of names for DateTime Items containing the start
+        times for each time period
+        - log: used to log debug information
+    """
+
+    now = DateTime().now()
+    most_recent_time = now.minusDays(1)
+    most_recent_state = items[ETOD_ITEM]
+
+    for time in start_times:
+
+        item_time = DateTime(str(items[time]))
+        trigger_time = to_today(items[time])
+
+        # Update the Item with today's date if it was for yesterday.
+        if item_time.isBefore(trigger_time):
+            log.debug("Item {} is yesterday, updating to today".format(time))
+            events.postUpdate(time, str(trigger_time))
+
+        # Get the etod state from the metadata.
+        state = get_value(time, NAMESPACE)
+
+        # If it's in the past but after most_recent, update most_recent.
+        if trigger_time.isBefore(now) and trigger_time.isAfter(most_recent_time):
+            log.debug("NOW:    {} start time {} is in the past but after {}"
+                     .format(state, trigger_time, most_recent_time))
+            most_recent_time = trigger_time
+            most_recent_state = get_value(time, NAMESPACE)
+
+        # If it's in the future, schedule a Timer.
+        elif trigger_time.isAfter(now):
+            log.debug("FUTURE: {} Scheduleing Timer for {}"
+                     .format(state, trigger_time))
+            timers.check(time, trigger_time,
+                         function=lambda: etod_transition(state))
+
+        # If it's in the past but not after most_recent_time we can ignore it.
+        else:
+            log.debug("PAST:   {} start time of {} is before now {} and before {}"
+                     .format(state, trigger_time, now, most_recent_time))
+
+    log.info("The current time of day is {}".format(most_recent_state))
+    send_command_if_different(ETOD_ITEM, most_recent_state)
+
+def trigger_generator():
+    """Generates rule triggers for all of the Items that have etod metadata"""
+    def generate_triggers(function):
+        for item_name in [i for i in items if get_metadata(i, NAMESPACE)]:
+            when("Item {} changed".format(item_name))
+        return(function)
+    return generate_triggers
+
+@rule("Ephemeris Time of Day", tags=["etod", "openhab-rules-tools"])
+@when("System started")
+@when("Time cron 0 2 0 * * ? *")
+@when("Item {} received command ON".format(ETOD_TRIGGER_ITEM))
+@trigger_generator()
+def ephem_tod(event):
+    """Rule to recalculate the times of day for today. It triggers at system
+    start, two minutes after midnight (to give Astro a chance to update the
+    times for today), when ETOD_TRIGGER_ITEM (default is CalculateETOD) receives
+    an ON command, or when any of the Items with etod metadata changes.
+    """
+
+    # Get the start times.
+    start_times = get_times(ephem_tod.log)
+
+    # If any are NULL, kick off the init rule.
+    null_items = [i for i in start_times if isinstance(items[i], UnDefType)]
+    if null_items:
+        ephem_tod.log.warn("The following Items are are NULL: {} kicking off "
+                           "initialization".format(null_items))
+        events.sendCommand("InitItems", "ON")
+        from time import sleep
+        sleep(5)
+
+    if [i for i in start_times if isinstance(items[i], UnDefType)]:
+        ephem_tod.log.error("There are still etod Items that are NULL, cancelling")
+        return
+
+    # Cancel existing Items and then generate all the timers for today.
+    timers.cancel_all()
+    create_timers(start_times, ephem_tod.log)
+
+def scriptUnloaded():
+    """Cancel all Timers at unload to avoid errors in the log."""
+    timers.cancel_all()

--- a/item_init/README.md
+++ b/item_init/README.md
@@ -36,4 +36,7 @@ Color MyLamp { init="123,45,67" }
 // Initialize TerhermostSetpoint to 70 but only if it's NULL or UNDEF, remove
 // the init metadata after start.
 Number ThermostatSetpoint { init="70"[override="False", clear="True"] }
+
+// Initialize a DateTime to a given time today
+DateTime NightTime { init="21:45:00" }
 ```

--- a/item_init/automation/jsr223/python/community/item_init/item_init.py
+++ b/item_init/automation/jsr223/python/community/item_init/item_init.py
@@ -53,8 +53,6 @@ def item_init(event):
 
     item_init.log.info("Initializing Items")
     for item_name in [i for i in items if get_metadata(i, "init")]:
-        cfg = get_metadata(item_name, "init")
-        item_init.log.info("Item {} cfg = {} ".format(item_name, cfg))
         value = get_value(item_name, "init")
 
         # Always update if override is True

--- a/timer_mgr/automation/lib/python/community/timer_mgr.py
+++ b/timer_mgr/automation/lib/python/community/timer_mgr.py
@@ -124,13 +124,12 @@ class TimerMgr(object):
 
         # No timer exists, create the Timer
         else:
-            item = ir.getItem(key)
             timer = ScriptExecution.createTimer(timeout,
                         lambda: self.__not_flapping(key))
-            self.timers[key] = { 'orig_state':   item.state,
-                                 'timer':        timer,
+            self.timers[key] = { 'timer':        timer,
                                  'flapping':     flapping_function,
                                  'not_flapping': function if function else self.__noop}
+
 
     def has_timer(self, key):
         """Checks to see if a Timer exists for the passed in key.


### PR DESCRIPTION
Initial implementation of Ephemeris Time of Day. It depends wholly on Item metadata.

Added the list of libraries with a description to the main README.

Fixed a bug in debounce for when states is not included.

Added a DateTime example to init_items to show that initializing with just the Time works. Removed some redundant lines from init_items.

Fixed the logger names in debounce and timer_utils. Updated to_datetime to support DateTime Items. Added a to_today function that takes a DateTime and updates the date to today.

Removed unused code from TimerMgr.

