### PR TITLE
Initial version of Expire binding repalcement

### DIFF
--- a/deferred/README.md
+++ b/deferred/README.md
@@ -12,13 +12,13 @@ Creating a Timer for this is possible but this library deals with all that book 
 The delay can be defined using a parsed duration string of the format "xd xh xm xs" (see parse_duration) or a DateTime.
 
 # How it works
-Import and call the `deferred` function and, if required, the `cancel` and `cancel_all` functions.
+Import and call the `defer` function and, if required, the `cancel` and `cancel_all` functions.
 
 ## deferred
 This is the function that will be used the most.
 
 ```python
-deferred(target, value, "5m", log, is_command=True)
+defer(target, value, "5m", log, is_command=True)
 ```
 
 Argument | Purpose
@@ -47,16 +47,16 @@ cancel_all()
 # Examples
 
 ```python
-from community.timer_mgr import deferred, cancel, cancel_all
+from community.timer_mgr import defer, cancel, cancel_all
 
 
 ...
 
     # In a Rule, send a command to Foo in 5 minutes
-    deferred("Foo", "ON", "5m", log)
+    defer("Foo", "ON", "5m", log)
 
     # In a Rule, send a n update to Foo in 5 minutes using DateTime
-    deferred("Foo", "OFF", DateTime().now().plusMinutes(5), log, is_command=False)
+    defer("Foo", "OFF", DateTime().now().plusMinutes(5), log, is_command=False)
 
     # Cancel the deffered action for Foo
     cancel("Foo")

--- a/expire/README.md
+++ b/expire/README.md
@@ -1,0 +1,74 @@
+# Drop in Replacement for Expire 1.x Binding
+This rule implements a replacement for the Expire 1.x binding.
+It is not intended to be a permament solution and likely will not be maintained for longafter OH 3.0 comes out.
+The purpose of the library is to be a drop in repalcement of the Expire binding to allow users who depend on the Expire binding the chance to move to openHAB 3.0 without needing to rework Rules and Item configs first.
+
+# Purpose
+Item metadata that is nearly identical to the bninding config for the Expire 1.x binding is used to define a base state and a time to wait after the Item changes from that state before updating or commanding the Item back to that state.
+
+# Requirements
+- `time_utils` to process Expire durations and it's needed by `timer_mgr` and deferred
+- `deferred` to schedul the command or update to the Item when it expires
+- `timer_mgr` to manage the Timer, needed by `deferred`
+
+# How it works
+
+When a 1.x version binding is uninstalled, it's binding config appears to openHAB as Item metadata.
+These rules find all the Items that have an expire metadata and reimplements the Expire 1.x binding's behavior.
+When an Item changes to a state different from the expire comnfigured state, a Timer is set for the duration.
+At the end of the time, the Item is updated to or commanded to the expire state.
+If the Item changes while a Timer exists, the Timer is either canceled if it changed to the expire state or it is rescheduled.
+
+Rules have a limitation that there is no event created when Item metadata is added, mofified, or removed.
+Therefore there is no way to know when you've changed the Item metadata for an Item.
+Thus, if it doesn't already exist, a `Reload_Expire` Item will be created that will recreate the Expire rule with new triggers based on the current metadata.
+After modifying expire Item metadata, send an `ON` command to the `Reload_Expire` Item or execute the `Reload Expire` rule in PaperUI by clicking the "play" icon next to the rule in the list.
+
+When the script is loaded or when the `Reload Expire` rule runs, all the Items with expire metadata are obtained and the configuration checked for validity.
+Invalid configs will generate errors in the logs.
+If the config is valid, changes to the Item will be added as a trigger to the Expire rule.
+The expected format is:
+
+```
+expire="<duration>[,[command=|state=]<new state>]"
+```
+
+Field | Purpose
+-|-
+`<duration>` | Required, a time duration of the format fully describvd in `parse_time`. In general it's of the format `wd xh ym zs` where w, x, y, z are numbers (floats are allowed) and d is days, h is hours, m is minutes and s is seconds. One of the four are required, spaces are optional.
+`[,]` | Optional, if supplying more that just the duration, separates the duration from the type of update and expire state. If just the duration is supplied, the Item will be updated to `UNDEF` after the duration.
+`[command=|state=]` | Optional field to indicate if the expire state should be sent as an update or a command. When omitted, state is the default (i.e. update).
+`<new state>` | Required if `,` was used, indicates the state the Item should be commanded to or updated to at the end of the expire time. Use `''` to represent the empty String (this differs from the Expire 1.x Binding). Use `'UNDEF'` or `'NULL`' to represent the strings `"UNDEF"` and `"NULL"` for String Items as opposed the `NULL` and `UNDEF` states.
+
+See the next section for examples.
+
+# Examples
+
+Examples (taken from the Expire1 Binding docs):
+
+Item Metadata | What it does
+-|-
+`expire="1h,command=STOP"` | Send the STOP command after one hour
+`expire="5m,state=0"` | Update state to 0 after five minutes
+`expire="3m12s,Hello"` | Update state to Hello after three minutes and 12 seconds
+`expire="2h"` | Update state to UNDEF 2 hours after the last value
+
+Unique to this implementation:
+Item Metadata | What it does
+-|-
+`expire="5s,state=''"` | Update a String Item to the empty String
+`expire="5s,state=UNDEF"` | For String Items, expires to UNDEF, not the string, "UNDEF"
+`expire="5s,state='UNDEF'"` | For String Items, expires to the String "UNDEF"
+`expire="0.5s,command=OFF"` | Send an OFF command in 500 msec
+
+Example Item:
+
+```
+Switch MyButton { expire="0.5,command=OFF" }
+```
+
+# Limitations
+
+Modifications to Item metadata require a refresh of the rule or a restart of openHAB to pick up.
+Note that Items that currently have a Timer set for them during the reload will not have a new Timer created.
+Instead these Timer will continue using the old config until cancelled or rescheduled.

--- a/expire/automation/jsr223/python/community/expire/expire.py
+++ b/expire/automation/jsr223/python/community/expire/expire.py
@@ -1,0 +1,271 @@
+"""
+Copyright July 7, 2020 Richard Koshak
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from core.rules import rule
+from core.triggers import when
+from core.metadata import get_value
+from core.log import logging, LOG_PREFIX, log_traceback
+from core.jsr223.scope import scriptExtension
+import community.time_utils
+reload(community.time_utils)
+from community.time_utils import parse_duration, to_datetime
+import community.deferred
+reload(community.deferred)
+from community import deferred
+
+ruleRegistry = scriptExtension.get("ruleRegistry")
+
+# Create an Item to trigger the rule on command if it doesn't exist.
+RELOAD_EXPIRE_ITEM = "Reload_Expire"
+if RELOAD_EXPIRE_ITEM not in items:
+    from core.items import add_item
+    add_item(RELOAD_EXPIRE_ITEM, item_type="Switch")
+
+# Logger to use before
+init_logger = logging.getLogger("{}.Expire Init".format(LOG_PREFIX))
+
+# Maps the UnDefType string representation with their actual types.
+special_types = { "UNDEF": UnDefType.UNDEF,
+                  "NULL":  UnDefType.NULL }
+
+@log_traceback
+def delete_rule(function):
+    """Deletes a rule attached to the passed in function, if it exists"""
+
+    if hasattr(function, "UID"):
+        ruleRegistry.remove(function.UID)
+        delattr(function, "triggers")
+        delattr(function, "UID")
+
+
+@log_traceback
+def get_config(i, log):
+    """Parses the expire metadata and generates a dict with the values. If the
+    config is not valid, None is returned.
+
+    The expected format is:
+
+    expire="<duration>[,[command=|state=]<new state>]"
+
+        - <duration>: a time duration of the format described in parse_time.
+        - [,]: if supplying more than just the duration, a comma is required
+        here.
+        - [command=|state=]: an optional definition of the type of of event to
+        send to this Item when it expires. If not supplied it defaults to
+        "state=".
+        - [<new state>]: an optional state that the Item get's updated (state)
+        or commanded (command) to when the time expires. Use '' to represent the
+        empty String (differs from Expire1 Binding). Use 'UNDEF' or 'NULL' to
+        represent the String rather than the state.
+
+    Examples (taken from the Expire1 Binding docs):
+        - expire="1h,command=STOP" (send the STOP command after one hour)
+        - expire="5m,state=0"      (update state to 0 after five minutes)
+        - expire="3m12s,Hello"     (update state to Hello after three minutes
+                                    and 12 seconds)
+        - expire="2h"              (update state to UNDEF 2 hours after the last
+                                    value)
+    Unique to this implementation:
+        - expire="5s,state=''"      (update a String Item to the empty String)
+        - expire="5s,state=UNDEF"   (for String Items, expires to UNDEF, not the
+                                     string, "UNDEF")
+        - expire="5s,state='UNDEF'" (for String Items, expires to the String
+                                     "UNDEF")
+    Argument:
+        - i : name of the Item to process the metadata
+        - log : logs warning explaining why a config is invalid
+    Returns:
+        None if the config is invalid.
+        A dict with:
+            - time : Duration string as defined in time_utils.parse_duration
+            - type : either "state" or "command"
+            - state : the Expire state
+    """
+
+    cfg = get_value(i, "expire")
+
+    # Separate the time from the command/update.
+    if cfg:
+        cfg = cfg.split(",")
+    else:
+        log.error("Invalid expire config: Item {} does not have an expire config"
+                  .format(i))
+        return None
+
+    # Check that the time part parses.
+    if not parse_duration(cfg[0], log):
+        log.error("Invalid expire config: Item {} does not have a valid duration string: {}"
+                  .format(i, cfg[0]))
+        return None
+
+    # Default to state updates and UNDEF.
+    event = "state"
+    state = "UNDEF"
+
+    # If there is more than one element in the split cfg, the user has overridden
+    # the defaults. Parse them out.
+    if len(cfg) > 1:
+        event_str = cfg[1].split("=")
+
+        # If there is an "=" that means we have both the event type and the state
+        # defined. Otherwise we only have the state.
+        #
+        # Preserve any white space until we know whether or not this is for a
+        # String Item.
+        if len(event_str) > 1:
+            event = event_str[0].strip().lower()
+            state = event_str[1]
+        else:
+            state = event_str[0]
+
+        # Convert "UNDEF" and "NULL" to their actual types. This let's us handle
+        # using the String "`UNDEF`" and "`NULL`".
+        if state.strip() in special_types:
+            state = special_types[state]
+        # If not a special type, remove any single quotes around the state.
+        else:
+            state = state.strip("'")
+
+        # Handle the case where the state is empty.
+        state = state if str(state).strip() != "" else UNDEF
+
+        # Force the state to a StringType if this is for a String type Item.
+        # This is required to set the string "UNDEF" and "NULL".
+        if ir.getItem(i).type == "String":
+            if isinstance(state, basestring):
+                state = StringType(state)
+        # Finally, strip whitespace for non String items.
+        elif isinstance(state, basestring):
+            state = state.strip()
+
+    # Make sure the event is valid
+    if event not in ["state", "command"]:
+        log.error("Invalid expire config: Unrecognized action '{}' for item '{}'"
+                  .format(event, item_name))
+        return None
+
+    if isinstance(state, UnDefType) and event == "command":
+        log.error("Invalid expire config: Cannot command Item {} to {}"
+                  .format(i, state))
+        return None
+
+    # Return the dict as a dict
+    return { "time": cfg[0], "type": event, "state": state }
+
+
+@log_traceback
+def expire_event(event):
+    """Called when any Item with a valid expire config changes state."""
+
+    # Cancel any deffered action if the new state is UnDefType.
+    if isinstance(event.itemState, UnDefType):
+        expire_event.log.debug("Item {} change to an UnDefType {}, cancelling timer"
+                 .format(event.itemName, event.itemState))
+        deferred.cancel(event.itemName)
+        return
+
+    # Get the configuration for the Item.
+    cfg = get_config(event.itemName, expire_event.log)
+    if not cfg:
+        exipre_event.log.error("Item {} has an invalid expire config")
+        deferred.cancel(event.itemName)
+        return
+
+    # Cancel the timer if we've changed to the expire state.
+    if unicode(event.itemState) == cfg["state"]:
+        expire_event.log.debug("Item {} has returned to the expired state {}, "
+                              "cancelling timer".format(event.itemName, cfg["state"]))
+        deferred.cancel(event.itemName)
+        return
+
+    # If we get to this point we need to schedule a deferred action to expire
+    # the Item to the configured state.
+    expire_event.log.debug("Scheduling expire timer for {} with duration {}, "
+                           "type {} and state {}".format(event.itemName,
+                                                         cfg["time"],
+                                                         cfg["type"],
+                                                         cfg["state"]))
+
+
+    deferred.defer(event.itemName, cfg["state"], cfg["time"],
+                   expire_event.log,
+                   is_command=True if cfg["type"] == "command" else False)
+
+@log_traceback
+def load_expire(event):
+    """Called at startup or when the Reload Expire rule is triggered, deletes
+    and recreates the Expire rule. Should be called at startup and when the
+    metadata is changed on Items since there is no event to do this
+    automatically.
+    """
+
+    init_logger.info("Creating Expire Rule...")
+
+    # Remove existing rule if it exists.
+    delete_rule(expire_event)
+
+    # Generate the rule triggers with the latest expire metadata.
+    expire_items = []
+    for i in [i for i in items if get_value(i, "expire")]:
+        if get_config(i, init_logger):
+            init_logger.debug("Creating a changed trigger for {}".format(i))
+            when("Item {} changed".format(i))(expire_event)
+            expire_items.append(i)
+
+    # Create the expire rule itself.
+    if hasattr(expire_event, "triggers"):
+        rule("Expire",
+             description="Drop in replacement for the Expire 1.x binding",
+             tags=["openhab-rules-tools","expire"])(expire_event)
+
+        if hasattr(expire_event, "UID"):
+            init_logger.info("Expire rule successfully created")
+        else:
+            init_logger.error("Failed to create Expire rule")
+
+    else:
+        init_logger.warn("No Items found with valid expire configs")
+
+    # Cancel any deferred actions that are schedule for Items that no longer
+    # have a valid expire config.
+    [deferred.cancel(i) for i in deferred.timers.timers if not i in expire_items]
+
+@log_traceback
+def scriptLoaded(*args):
+    """Create the Expire Rule, based on additions to the original submission
+    of the Expire binding to the openhab-helper-libraries by CrazyIvan359.
+    """
+
+    # Create the rule that creates the expire rule on command.
+    when("Item {} received command ON".format(RELOAD_EXPIRE_ITEM))(load_expire)
+    rule("Reload Expire",
+         description="Automatically generated rule that recreats the Expire Rule",
+         tags=["expire", "openhab-rules-tools"])(load_expire)
+
+    if hasattr(load_expire, "UID"):
+        init_logger.info("Reload Expire rule successfully created")
+    else:
+        init_logger.error("Failed to create Reload Expire rule")
+
+    # Create the actual expire rule.
+    load_expire(None)
+
+@log_traceback
+def scriptUnloaded():
+    """Cancel all the timers."""
+
+    deferred.cancel_all()
+    delete_rule(expire_event)
+    delete_rule(load_expire)

--- a/item_init/automation/jsr223/python/community/item_init/item_init.py
+++ b/item_init/automation/jsr223/python/community/item_init/item_init.py
@@ -27,7 +27,7 @@ if TRIGGER_ITEM not in items:
 
 @rule("Initialize Items",
       description="Updates Items with an initialization value at System start",
-      tags=["init"])
+      tags=["init", "openhab-rules-tools"])
 @when("System started")
 @when("Item {} received command ON".format(TRIGGER_ITEM))
 def item_init(event):

--- a/time_utils/automation/lib/python/community/time_utils.py
+++ b/time_utils/automation/lib/python/community/time_utils.py
@@ -44,6 +44,7 @@ def parse_duration(time_str, log=logging.getLogger("{}.time_utils".format(LOG_PR
         A ``datetime.timedelta`` object representing the supplied time duration
         or ``None`` if ``time_str`` cannot be parsed.
     """
+
     parts = duration_regex.match(time_str)
     if parts is None:
         log.warn("Could not parse any time information from '{}'. Examples "
@@ -61,6 +62,7 @@ def delta_to_datetime(td):
     Returns:
         A Joda DateTime td from now.
     """
+
     return (DateTime.now().plusDays(td.days)
                .plusSeconds(td.seconds)
                .plusMillis(td.microseconds//1000))
@@ -73,6 +75,7 @@ def parse_duration_to_datetime(time_str, log=logging.getLogger("{}.time_utils".f
     Returns:
         A Joda DateTime time_str from now
     """
+
     return delta_to_datetime(parse_duration(time_str, log))
 
 def is_iso8601(dt_str):
@@ -82,6 +85,7 @@ def is_iso8601(dt_str):
     Returns:
         True if dt_str conforms to dt_str and False otherwise
     """
+
     try:
         if iso8601_regex(dt_str) is not None:
             return True
@@ -103,6 +107,7 @@ def to_datetime(when, log=logging.getLogger("{}.time_utils".format(LOG_PREFIX)))
     Returns:
         - DateTime specified by when
     """
+
     dt = None
     if isinstance(when, DateTime):
         dt = when
@@ -113,14 +118,23 @@ def to_datetime(when, log=logging.getLogger("{}.time_utils".format(LOG_PREFIX)))
     elif isinstance(when, (scope.DecimalType, scope.PercentType,
                            scope.QuantityType)) :
         dt = DateTime().now().plusMillis(when.intValue())
-    elif isinstance(when, str):
+    elif isinstance(when, (str, unicode)):
         if is_iso8601(when):
             dt = DateTime(when)
         else:
             dt = parse_duration_to_datetime(when, log)
+
     return dt
 
 def to_today(when, log=logging.getLogger("{}.time_utils".format(LOG_PREFIX))):
+    """Takes a when (see to_datetime) and updates the date to today.
+    Arguments:
+        - when : One of the types or formats supported by to_datetime
+        - log: optional logger, when not supplied one is created for logging errors
+    Returns:
+        - DateTime specified by when with today's date.
+    """
+
     dt = to_datetime(when, log)
     now = dt.now()
 

--- a/timer_mgr/automation/lib/python/community/timer_mgr.py
+++ b/timer_mgr/automation/lib/python/community/timer_mgr.py
@@ -65,6 +65,7 @@ class TimerMgr(object):
 
     def __init__(self):
         """ Initialize the timers dict."""
+
         self.timers = {}
 
     def __not_flapping(self, key):
@@ -73,6 +74,7 @@ class TimerMgr(object):
         Args:
             key: the key of the Timer that called the function
         """
+
         try:
             self.timers[key]['not_flapping']()
         finally:
@@ -110,6 +112,7 @@ class TimerMgr(object):
             - reschedule: Optional flag that causes the Timer to be rescheduled
             when the key already has a Timer. Defaults to False.
         """
+
         timeout = to_datetime(when)
 
         # Timer exists: if the reschedule flag is set, reschedule it, otherwise
@@ -137,6 +140,7 @@ class TimerMgr(object):
             - key: Name of the Timer
         Returns: True if there is a Timer for that key.
         """
+
         return key in self.timers
 
     def cancel(self, key):
@@ -144,6 +148,7 @@ class TimerMgr(object):
         Arguments:
             - key: Name of Timer.
         """
+
         if not self.has_timer(key):
             return
         self.timers[key]['timer'].cancel()
@@ -153,6 +158,7 @@ class TimerMgr(object):
         """
         Cancels any existing Timers.
         """
+
         for timer in self.timers.values():
             if not timer['timer'].hasTerminated():
                 timer['timer'].cancel()


### PR DESCRIPTION
deferred:
- Renamed the `deferred` function to `defer` as it's more grammatically correct and indicative of what it does.
- Added the duration `when` to the `timer_body` so it can be logged with the Item name and state and action type

item_init:
- Added openhab-rules-tools to the tags

time_utils:
- Added spaces after docstrings.
- Added docstring for to_today
- Added unicode for duration string detection in to_datetime

timer_mgr:
- Added spaces after docstrings

expire:
- Initial implementation of drop in replacement for the expire binding.

Signed-off-by: Richard Koshak <rlkoshak@gmail.com>