### PR TITLE
Implemented MQTT Event Bus, work around cron triggers

### DIFF
--- a/debounce/automation/jsr223/python/community/debounce/debounce.py
+++ b/debounce/automation/jsr223/python/community/debounce/debounce.py
@@ -113,6 +113,10 @@ def load_debounce(event):
     automatically.
     """
 
+    if nor delete_rule(debounce, init_logger):
+        init_logger.error("Failed to delete rule!")
+        return
+
     debounce_items = load_rule_with_metadata("debounce", get_config, "changed",
             "Debounce", debounce, init_logger,
             description=("Delays updating a proxy Item until the configured "

--- a/mqtt_eb/README.md
+++ b/mqtt_eb/README.md
@@ -1,0 +1,126 @@
+# MQTT Event Bus
+A set of rules that enable the creation of an MQTT Event Bus.
+These rules do require some configruation of the MQTT binding as well as the definition of some variables in configuration.py.
+
+# Purpose
+There are times where a user has more than one instance of openHAB running and needs to mirror the Items hosted in one instance in the other instance.
+For example, it might be required to host an instance of OH closer to the hardware than a "main" instance.
+A user may need to run an older version of OH for compatability reasons but want to take advantage of new capabilities as well.
+There may be a remote instance of openHAB monitoring and controlling a separate building in another location that needs to be monitored from the "main" openHAB.
+
+The event bus can support a one-to-one relationship between two instances of openHAB or a star shaped topilogy where there is one main openHAB instance with many satelite instances feeding into it.
+The library would need modifications to support a many-to-many topology.
+More on topologies is below.
+
+# Requirements
+- `rules_tools` used to reload the rules when the configuration changes.
+
+# How it works
+The rules are split into two parts: publisher and subscription.
+
+## Prerequisites
+As one would expect, these rules require the MQTT 2.x binding or later to be installed.
+There needs to be an MQTT Broker Thing manually created and configured to connect and that Thing should show as ONLINE.
+Take note of the broker Thing's ID.
+Additional configuration is required that is specific to the Publsiher and Subscriber described below.
+More details about configuring the MQTT 2.x binding for use with the event bus can be found at [MQTT 2.5 Event Bus](https://community.openhab.org/t/mqtt-2-5-event-bus/76938).
+
+## Publisher
+The Publisher rules are responsible for publishing updates and command to the Item's MQTT topic.
+The topic is defined by:
+
+    <openHAB name>/out/<Item Name>/[state|command]
+
+So, given "main-openhab" as the `<openHAB name>` and "MyItem" as the `<Item Name>`, updates will be published to `main-openhab/out/MyItem/state` and command published to `main-openhab/out/MyItem/command`.
+`<openHAB name>` is defined in `configuration.py` as `mqtt_eb_name`.
+
+In addition to publish Items updates and commands, the Publisher will also publish the message `ONLINE` to `<openHAB name>/status` when it first comes online as a retained message.
+The MQTT broker Thing should be configured to publish `OFFLINE` as a retained message to this same topic as the LWT.
+This allows other instances to know when that instance is online or offline.
+
+The publisher also has a few variables that need to be created and populated in `configuration.py`.
+
+Variable | Purpose
+-|-
+`mqtt_eb_name` | The name used as the root of the event bus topics. It must be a string containing only characters allowed in an MQTT topic.
+`mqtt_eb_broker` | Set to the Thing ID of the MQTT broker. This is used with the publsihMQTT Action to publish the messages.
+`mqtt_eb_puball` | An optional variable. When it's absent or set to True all updates and all commands to the all Items are publsihed. When False, only those Items tagged with `eb_update` have their updates published and only those Items tagged with `eb_command` have their command  published.
+
+After changing any of the three varaibles in `configuration.py` or changing the tags on any Items, the rule needs to be reloaded.
+Either send an `ON` command to `Reload_MQTT_PUB` (it will be created automatically if it doesn't already exist) or trigger the "Reload MQTT event bus Publisher" rule manually from PaperUI which will recreate the rule with the new configuration.
+
+## Subscriber
+The Subscriber rule is responsible for receiving the messages published to the event bus and updating or commanding the Items that have the same name as indicated by the topic with the message received.
+
+The subscriber receives all the messages on the indicated event bus topic list and parses out the Item name and event type (state or command) from the topic.
+If an Item of that name exists, it is updated or commanded with the contents of the message.
+If an Item of that name does not exist, nothing happens.
+
+The subscriber requires an event trigger Channel to be created on the MQTT Broker Thing.
+The subscription for that channel should be `<openHAB name>/[in|out]/*`.
+What to put for the two options depends on the desired topology.
+
+Once the trigger Channel is created, the Channel ID needs to be set to the `mqtt_eb_chan` variable in `configuration.py`.
+If `mqtt_eb_chan` is changed, send an `ON` command to `Reload_MQTT_SUB` or trigger the "Reload MQTT event bus Subscription" rule manually from PaperUI which will recreate the rule with the new Channel as the trigger.
+
+## One-to-One Topology
+In a One-to-One Topology, there are only two instances of openHAB.
+For this discussion let's call them `local` and `remote`.
+Then configure the two instances as follows:
+
+Name|Publish Topic|Subscribe Topic
+-|-|-
+`local` | `local/out/<Item Name>/[state|command]` | `remote/out/*`
+`remote` | `remote/out/<Item Name>/[state|command]` | `local/out/*`
+
+Local publishes to it's own out topic and subscribes to remote's out topic.
+Conversly, remote publishes to it's own out topic and subscribes to local's out topic.
+
+## Star Topology
+In a star topology there is one central 'main' openHAB instance and multiple "satelite" openHAB instances.
+All events from the "satelite" instances need to be published to 'main' and all commands from `main` need to be published to the "satelites".
+To facilitate this we will configure the instances as follows:
+
+Name | Publish Topic | Subscribe Topic
+-|-|-
+`main` | `main/out/<Item Name>/command` | `main/in/*`
+`satelite1` | `main/in/<Item Name>/[state|command]` | `main/out/*`
+`satelite2` | `main/in/<Item Name>/[state|command]` | `main/out/*`
+
+Notice that the root of the topics is `main` even for the satelites.
+Also bnoice that only commands are published by `main`.
+This is to prevent infinite loops where `main` publishes an update, `satelite1` picks it up and updates the Item which generates a state message which `main` picks up and updates the Item and so on.
+Note that this is not enforced in the code.
+It is up to you to not configure Items to publish updates from `main` (i.e. don't tag any Items with `eb_update`).
+
+All Items that need to be synchronized to `main` must have a unique name across all the Items in all the satelite instances.
+
+## Many to Many Topology
+This topology is not recommended for use because it is almost impossible to avoid infinite loops.
+
+# Examples
+
+## Taging Items for the event bus
+```
+Switch Foo [eb_command] // publishes only commands to the event bus
+String Bar [eb_update] // publishes only updates to the event bus
+Number Baz [eb_command,eb_update] // publishes both command and updates to the event bus
+```
+
+## Example `configuration.py`
+
+```python
+# The Channel ID of the MQTT Event Bus subscription channel
+mqtt_eb_in_chan = "mqtt:broker:mosquitto:eventbus"
+
+# The name to use for this instance of openHAB, forms the root of the MQTT topic
+# hierarchy.
+mqtt_eb_name = "remote-openhab"
+
+# Thing ID for the MQTT broker Thing.
+mqtt_eb_broker = "mqtt:broker:mosquitto"
+
+# Optional flag, when True all Item commands and updates are puiblished.
+# Defaults to True.
+mqtt_eb_puball = True
+```

--- a/mqtt_eb/automation/jsr223/python/community/mqtt_eb/mqtt_eb_pub.py
+++ b/mqtt_eb/automation/jsr223/python/community/mqtt_eb/mqtt_eb_pub.py
@@ -1,0 +1,183 @@
+"""
+Copyright July 10, 2020 Richard Koshak
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from core.log import logging, LOG_PREFIX, log_traceback
+from community.rules_utils import create_simple_rule, delete_rule, create_rule
+
+init_logger = logging.getLogger("{}.mqtt_eb".format(LOG_PREFIX))
+
+@log_traceback
+def check_config(log):
+    """Verifies that all the settings exist and are usable."""
+
+    try:
+        from configuration import mqtt_eb_name
+    except:
+        log.error("mqtt_eb_name is not defined in configuration.py!")
+        return False
+
+    broker = None
+    try:
+        from configuration import mqtt_eb_broker
+        broker = mqtt_eb_broker
+    except:
+        log.error("mqtt_eb_broker is not defined in configuration.py!")
+        return False
+
+    if not actions.get("mqtt", broker):
+        log.error("{} is not a valid broker Thing ID".format(broker))
+        return False
+    return True
+
+@log_traceback
+def mqtt_eb_pub(event):
+    """Called when a configured Item is updated or commanded and publsihes the
+    event to the event bus.
+    """
+
+    if not check_config(mqtt_eb_pub.log):
+        init_logger.error("Cannot publish event bus event, deleting rule")
+        delete_rule(mqtt_eb_pub, init_logger)
+        return
+
+    from configuration import mqtt_eb_name, mqtt_eb_broker
+
+    is_cmd = hasattr(event, 'itemCommand')
+    msg = str(event.itemCommand if is_cmd else event.itemState)
+    topic = "{}/out/{}/{}".format(mqtt_eb_name, event.itemName,
+                                  "command" if is_cmd else "state")
+    retained = False if is_cmd else True
+    init_logger.info("Publishing {} to  {} on {} with retained {}"
+                     .format(msg, topic, mqtt_eb_broker, retained))
+    action = actions.get("mqtt", mqtt_eb_broker)
+    if action:
+        action.publishMQTT(topic, msg, retained)
+    else:
+        init_logger.error("There is no broker Thing {}!".format(mqtt_eb_broker))
+
+@log_traceback
+def load_publisher():
+
+    # Delete the old publisher rule.
+    if not delete_rule(mqtt_eb_pub, init_logger):
+        init_logger("Failed to delete rule!")
+        return False
+
+    # Default to publishing all updates and all commands for all Items.
+    puball = True
+    try:
+        from configuration import mqtt_eb_puball
+        puball = mqtt_eb_puball
+    except:
+        init_logger.warn("No mqtt_eb_puball in configuration.py, "
+                                  "defaulting to publishing all Items")
+
+    # Don't bother to create the rule if we can't use it.
+    if not check_config(init_logger):
+        init_logger.error("Cannot create MQTT event bus publication rule!")
+        return False
+
+    triggers = []
+
+    # Create triggers for all Items.
+    if puball:
+        [triggers.append("Item {} received update".format(i))
+         for i in items]
+        [triggers.append("Item {} received command".format(i))
+         for i in items]
+
+    # Create triggers only for those Items with eb_update and eb_command tags.
+    else:
+        [triggers.append("Item {} received update".format(i))
+         for i in items
+         if ir.getItem(i).getTags().contains("eb_update")]
+        [triggers.append("Item {} received command".format(i))
+         for i in items
+         if ir.getItem(i).getTags().contains("eb_command")]
+
+    # No triggers, no need for the rule.
+    if not triggers:
+        init_logger.warn("No event bus Items found")
+        return False
+
+    # Create the rule to publish the events.
+    if not create_rule("MQTT Event Bus Publisher", triggers, mqtt_eb_pub,
+                       init_logger,
+                       description=("Publishes updates and commands on "
+                                    "configured Items to the configured "
+                                    "event bus topics"),
+                       tags=["openhab-rules-tools","mqtt_eb"]):
+        init_logger.error("Failed to create MQTT Event Bus Publisher!")
+        return False
+
+    return True
+
+@log_traceback
+def online(event):
+    """Publishes ONLINE to mqtt_eb_name/status on System started."""
+
+    init_logger.info("Reporting the event bus as ONLINE")
+    from configuration import mqtt_eb_broker, mqtt_eb_name
+    actions.get("mqtt", mqtt_eb_broker).publishMQTT("{}/status"
+                                                    .format(mqtt_eb_name),
+                                                    "ONLINE", True)
+
+@log_traceback
+def load_online():
+    """Loads the online status publishing rule."""
+
+    # Delete the old online rule.
+    if not delete_rule(online, init_logger):
+        init_logger("Failed to delete rule!")
+        return False
+
+    triggers = ["System started"]
+
+    if not create_rule("MQTT Event Bus Online", triggers, online, init_logger,
+                       description=("Publishes ONLINE to the configured LWT "
+                                    "topic."),
+                       tags=["openhab-rules-tools","mqtt_eb"]):
+        init_logger.error("Failed to create MQTT Event Bus Online rule!")
+
+@log_traceback
+def load_mqtt_eb_pub(event):
+    """Deletes and recreates the MQTT Event Bus publisher and online rules."""
+
+    # Reload to get the latest config parameters.
+    import configuration
+    reload(configuration)
+
+    if load_publisher():
+        load_online()
+
+@log_traceback
+def scriptLoaded(*args):
+    """Creates and then calls the Reload MQTT Event Bus Publisher rule."""
+
+    if create_simple_rule("Reload_MQTT_PUB",
+                          "Reload MQTT Event Bus Publisher",
+                          load_mqtt_eb_pub, init_logger,
+                          description=("Reload the MQTT Event Bus publisher "
+                                       "rule. Run when changing configuration.py"),
+                          tags=["openhab-rules-tools","mqtt_eb"]):
+        load_mqtt_eb_pub(None)
+
+@log_traceback
+def scriptUnloaded():
+    """Deletes the MQTT Event Bus Publisher and Online rules and the reload rule."""
+
+    delete_rule(load_mqtt_eb_pub, init_logger)
+    delete_rule(mqtt_eb_pub, init_logger)

--- a/mqtt_eb/automation/jsr223/python/community/mqtt_eb/mqtt_eb_sub.py
+++ b/mqtt_eb/automation/jsr223/python/community/mqtt_eb/mqtt_eb_sub.py
@@ -1,0 +1,91 @@
+"""
+Copyright July 10, 2020 Richard Koshak
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from core.log import logging, LOG_PREFIX, log_traceback
+from community.rules_utils import create_simple_rule, delete_rule, create_rule
+
+init_logger = logging.getLogger("{}.mqtt_eb".format(LOG_PREFIX))
+
+@log_traceback
+def mqtt_eb_sub(event):
+    """Called when a new message is received on the event bus subscription.
+    Splits the topic from the state using "#" and extracts the item and event
+    type from the topic.
+
+    Any message for an Item that doesn't exist generates a debug message in the
+    log.
+    """
+
+    topic = event.event.split("#")[0]
+    state = event.event.split("#")[1]
+    item_name = topic.split("/")[2]
+    event_type = topic.split("/")[3]
+
+    if item_name not in items:
+        mqtt_eb_sub.log.debug("Local openHAB does not have Item {}, ignoring."
+                             .format(item_name))
+    elif event_type == "command":
+        mqtt_eb_sub.log.debug("Received command {} for Item {}"
+                              .format(state, item_name))
+        events.sendCommand(item_name, state)
+    else:
+        mqtt_eb_sub.log.debug("Received update {} for Item {}"
+                              .format(state, item_name))
+        events.postUpdate(item_name, state)
+
+@log_traceback
+def load_mqtt_eb_sub(event):
+    """Deletes and recreates the MQTT Event Bus subscription rule."""
+
+    # Delete the old rule
+    delete_rule(mqtt_eb_sub, init_logger)
+
+    # Reload to get the latest subscription channel
+    import configuration
+    reload(configuration)
+    try:
+        from configuration import mqtt_eb_in_chan
+    except:
+        load_mqtt_eb_sub.log.error("mqtt_eb_in_chan is not defined in "
+                                   "configuration.py")
+        return
+
+    # Add the trigger
+    triggers = ["Channel {} triggered".format(mqtt_eb_in_chan)]
+    if not create_rule("MQTT Event Bus Subscription", triggers, mqtt_eb_sub,
+            load_mqtt_eb_sub.log,
+            description=("Triggers by an MQTT event Channel and updates or "
+                         "commands based on the topic the message came from"),
+            tags=["openhab-rules-tools","mqtt_eb"]):
+        load_mqtt_eb_sub.log.error("Failed to create MQTT Event Bus Subscription!")
+
+@log_traceback
+def scriptLoaded(*args):
+    """Creates and then calls the Reload MQTT Event Bus Subsciption rule."""
+
+    if create_simple_rule("Reload_MQTT_SUB",
+                          "Reload MQTT Event Bus Subscription",
+                          load_mqtt_eb_sub, init_logger,
+                          description=("Reload the MQTT Event Bus subscription "
+                                       "rule. Run when changing configuration.py"),
+                          tags=["openhab-rules-tools","mqtt_eb"]):
+        load_mqtt_eb_sub(None)
+
+@log_traceback
+def scriptUnloaded():
+    """Deletes the MQTT Event Bus Subscription rule and the reload rule."""
+
+    delete_rule(load_mqtt_eb_sub, init_logger)
+    delete_rule(mqtt_eb_sub, init_logger)

--- a/mqtt_eb/automation/lib/python/configuration.py.mqtt_eb-example
+++ b/mqtt_eb/automation/lib/python/configuration.py.mqtt_eb-example
@@ -1,0 +1,13 @@
+# The Channel ID of the MQTT Event Bus subscription channel
+mqtt_eb_in_chan = "mqtt:broker:broker:eventbus"
+
+# The name to use for this instance of openHAB, forms the root of the MQTT topic
+# hierarchy.
+mqtt_eb_name = "remote-openhab"
+
+# Thing ID for the MQTT broker Thing.
+mqtt_eb_broker = "mqtt:broker:mosquitto"
+
+# Optional flag, when True all Item commands and updates are puiblished.
+# Defaults to True.
+mqtt_eb_puball = True


### PR DESCRIPTION
Initial submission of the MQTT Event Bus.

debounce:
- delete the old rule and log an error if the deletion fails

ephem_tod:
- Time cron triggers appear not to be working, replaced the system started trigger with a direct function call and the cron triggers with a timer. Reworked the load method to use load_rule_with_metadata since we don't need custom rule triggers any longer.

Signed-off-by: Richard Koshak <rlkoshak@gmail.com>