### PR TITLE
Converted rate_limit to use time_utils to define how long to limit

### DIFF
--- a/deferred/automation/lib/python/community/deferred.py
+++ b/deferred/automation/lib/python/community/deferred.py
@@ -32,9 +32,9 @@ def timer_body(target, value, is_command, time, log):
         - time: the original time string
         - log: logger passed in from the Rule that is using this.
     """
-    log.info("{} {} to {} after {}"
-             .format("Commanding" if is_command else "Updating", target, value,
-                     time))
+    log.debug("{} {} to {} after {}"
+              .format("Commanding" if is_command else "Updating", target, value,
+                      time))
     if is_command:
         events.sendCommand(target, str(value))
     else:

--- a/rate_limit/README.md
+++ b/rate_limit/README.md
@@ -7,6 +7,8 @@ Andy commands that are sent to the class before the time has expired will be ign
 
 This class is similar to the gatekeeper class except that isntead of queueing up the commands, commands that occur during the timeout are ignored.
 
+# Requires
+- `time_utils` for converting many different ways to represent a time for the limit to a DateTime.
 # How it works
 Instantiate the RateLimit class.
 Call the `run` command with the amount of time to block.

--- a/rate_limit/test/rate_limit-tests.py
+++ b/rate_limit/test/rate_limit-tests.py
@@ -13,6 +13,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+import community.rate_limit
+reload(community.rate_limit)
 from community.rate_limit import RateLimit
 import time
 from core.log import logging, LOG_PREFIX
@@ -28,15 +30,15 @@ try:
     log.info("Starting rate_limit tests")
     rate_limit = RateLimit()
 
-    rate_limit.run(test, secs=2)
+    rate_limit.run(test, 2)
     assert func_called, "Test1: function was not called"
 
     func_called = False
-    rate_limit.run(test, secs=2)
+    rate_limit.run(test, "2s")
     assert not func_called, "Test2: function was called"
 
     time.sleep(2)
-    rate_limit.run(test, secs=2)
+    rate_limit.run(test, "2s")
     assert func_called, "Test3: function was not called"
 
 except AssertionError:


### PR DESCRIPTION
Implements #15 

deferred: converted the log when the timer ends to a debug

Signed-off-by: Richard Koshak <rlkoshak@gmail.com>