### PR TITLE
Expire event type to reset timer

### DIFF
--- a/expire/README.md
+++ b/expire/README.md
@@ -3,6 +3,8 @@ This rule implements a replacement for the Expire 1.x binding.
 It is not intended to be a permanent solution and likely will not be maintained for long after OH 3.0 comes out.
 The purpose of the library is to be a drop in replacement of the Expire binding to allow users who depend on the Expire binding the chance to move to openHAB 3.0 without needing to rework Rules and Item configs first.
 
+Please note the difference that with the Expire binding, item expiration timers got reset on an "received update" event, whereas this script per default resets on an "changed" event. I.e. with this script, one will get expirations if items are updated with the same value / their value does not change. To change this behavior, modify the script variable `UPDATE_EVENT`.
+
 # Purpose
 Item metadata that is nearly identical to the binding config for the Expire 1.x binding is used to define a base state and a time to wait after the Item changes from that state before updating or commanding the Item back to that state.
 

--- a/expire/README.md
+++ b/expire/README.md
@@ -3,8 +3,6 @@ This rule implements a replacement for the Expire 1.x binding.
 It is not intended to be a permanent solution and likely will not be maintained for long after OH 3.0 comes out.
 The purpose of the library is to be a drop in replacement of the Expire binding to allow users who depend on the Expire binding the chance to move to openHAB 3.0 without needing to rework Rules and Item configs first.
 
-Please note the difference that with the Expire binding, item expiration timers got reset on an "received update" event, whereas this script per default resets on an "changed" event. I.e. with this script, one will get expirations if items are updated with the same value / their value does not change. To change this behavior, modify the script variable `UPDATE_EVENT`.
-
 # Purpose
 Item metadata that is nearly identical to the binding config for the Expire 1.x binding is used to define a base state and a time to wait after the Item changes from that state before updating or commanding the Item back to that state.
 
@@ -20,7 +18,7 @@ When a 1.x version binding is uninstalled, it's binding config appears to openHA
 These rules find all the Items that have an expire metadata and reimplements the Expire 1.x binding's behavior.
 When an Item changes to a state different from the expire configured state, a Timer is set for the duration.
 At the end of the time, the Item is updated to or commanded to the expire state.
-If the Item changes while a Timer exists, the Timer is either canceled if it changed to the expire state or it is rescheduled.
+If for the Item a "received update" event is triggered (which is triggered even when the value stays the same) while a Timer exists, the Timer is either canceled if the item changed to the expire state or the timer is rescheduled.
 
 Rules have a limitation that there is no event created when Item metadata is added, modified, or removed.
 Therefore there is no way to know when you've changed the Item metadata for an Item.

--- a/expire/automation/jsr223/python/community/expire/expire.py
+++ b/expire/automation/jsr223/python/community/expire/expire.py
@@ -29,11 +29,6 @@ init_logger = logging.getLogger("{}.Expire Init".format(LOG_PREFIX))
 special_types = { "UNDEF": UnDefType.UNDEF,
                   "NULL":  UnDefType.NULL }
 
-# Define on which event the expiration timer should be reset. Prominent options:
-# received update   -> resets as soon as an update arrives, even if the value does not change
-# changed           -> resets after an update that changes the value of the item
-UPDATE_EVENT = "changed"
-
 @log_traceback
 def get_config(i, log):
     """Parses the expire metadata and generates a dict with the values. If the
@@ -196,7 +191,7 @@ def load_expire(event):
     automatically.
     """
 
-    expire_items = load_rule_with_metadata("expire", get_config, UPDATE_EVENT,
+    expire_items = load_rule_with_metadata("expire", get_config, "received update",
                    "Expire", expire_event, init_logger,
                    description="Drop in replacement for the Expire 1.x binding",
                    tags=["openhab-rules-tools","expire"])

--- a/expire/automation/jsr223/python/community/expire/expire.py
+++ b/expire/automation/jsr223/python/community/expire/expire.py
@@ -29,6 +29,11 @@ init_logger = logging.getLogger("{}.Expire Init".format(LOG_PREFIX))
 special_types = { "UNDEF": UnDefType.UNDEF,
                   "NULL":  UnDefType.NULL }
 
+# Define on which event the expiration timer should be reset. Prominent options:
+# received update   -> resets as soon as an update arrives, even if the value does not change
+# changed           -> resets after an update that changes the value of the item
+UPDATE_EVENT = "changed"
+
 @log_traceback
 def get_config(i, log):
     """Parses the expire metadata and generates a dict with the values. If the
@@ -191,7 +196,7 @@ def load_expire(event):
     automatically.
     """
 
-    expire_items = load_rule_with_metadata("expire", get_config, "changed",
+    expire_items = load_rule_with_metadata("expire", get_config, UPDATE_EVENT,
                    "Expire", expire_event, init_logger,
                    description="Drop in replacement for the Expire 1.x binding",
                    tags=["openhab-rules-tools","expire"])

--- a/expire/automation/jsr223/python/community/expire/expire.py
+++ b/expire/automation/jsr223/python/community/expire/expire.py
@@ -146,7 +146,7 @@ def get_config(i, log):
 
 @log_traceback
 def expire_event(event):
-    """Called when any Item with a valid expire config changes state."""
+    """Called when any Item with a valid expire config receives an update."""
 
     # Cancel any deffered action if the new state is UnDefType.
     if isinstance(event.itemState, UnDefType):


### PR DESCRIPTION
Hi @rkoshak , thanks for the script. When I set it up on my machine, I got lots of expiration events. After some tests, it seems that the old 1.x expire binding does not check for an actual value change, but for any update to an item.
I thus provide 2 things in this PR:

1. A new variable in the script to change the event type to listen to
2. A paragraph in the readme.md file to inform users of this difference.

Of course, the other approach would be to change the default behavior of the script to "received udpate", but I don't know what impact that would have, as others might rely on it. so I opted for this...

BR,
Alex