### PR TITLE
Fixed a bug

### DIFF
--- a/ephem_tod/javascript/ephemTimeOfDay.yml
+++ b/ephem_tod/javascript/ephemTimeOfDay.yml
@@ -116,12 +116,12 @@ actions:
             return item + " has type " + type + " which requires a 'set' value to be defined.";
           }
           
-          if(type == "custom" && getValue(item, ETOD_NAMESPACE, "file")) {
+          if(type == "custom" && getValue(item, ETOD_NAMESPACE, "file") === null ) {
             return item + " has type " + type + " which requires a 'file' value to be defined.";
           }
           
           return null;
-        }
+        
 
 
         /**


### PR DESCRIPTION
The metadata of a custom etod was not checked against null. With other words, if you have used the metadata 'file', it still produce an error as if you haven't use the metadata 'file'