### PR TITLE
Added option to prevent timer self cleanup incl. tests

### DIFF
--- a/timer_mgr/python/test/timer_mgr-tests.py
+++ b/timer_mgr/python/test/timer_mgr-tests.py
@@ -50,10 +50,10 @@ try:
 
     # Test that timer_expired was called when the timer expired,
     # timer_running_called is not called.
-    sleep(0.51)
+    sleep(0.55)
     assert not timers.has_timer(test_name), "Test1: Timer still exists"
     assert timer_expired_called, "Test1: Timer expired was not called"
-    assert not timer_running_called, "Teste1: Timer running was called"
+    assert not timer_running_called, "Test1: Timer running was called"
 
     # Test for timer_running get's called if checked and timer exists
     timer_expired_called = False
@@ -67,7 +67,7 @@ try:
     assert not timers.has_timer(test_name), "Test2: Timer still exists"
     assert not timer_expired_called, "Test2: Expired called too soon"
     assert timer_running_called, "Test2: Flapping was not called"
-    sleep(0.51)
+    sleep(0.55)
 
     # Test that if no function is passed we can call timer_running
     timer_expired_called = False
@@ -79,7 +79,7 @@ try:
     assert not timer_running_called, "Test3: Running was called too soon"
     timers.check(test_name, DecimalType(1), flapping_function=timer_running) # openHAB type test
     assert not timers.has_timer(test_name), "Test3: Timer still exists"
-    sleep(0.51)
+    sleep(0.55)
     assert not timer_expired_called, "Test3: Expired called"
     assert timer_running_called, "Test3: Flapping was not called"
 
@@ -97,7 +97,7 @@ try:
     assert timers.has_timer(test_name), "Test4: Timer no longer exists"
     assert not timer_expired_called, "Test4: Expired called too soon"
     assert timer_running_called, "Test4: Flapping not called"
-    sleep(0.51)
+    sleep(0.55)
     assert not timers.has_timer(test_name), "Test4: Timer still exists"
     assert timer_expired_called, "Test4: Expired not called"
     assert timer_running_called, "Test4: Flapping called."
@@ -110,7 +110,7 @@ try:
     assert timers.has_timer(test_name), "Test5: Timer does not exist"
     timers.cancel(test_name)
     assert not timers.has_timer(test_name), "Test5: Timer still exists after cancel"
-    sleep(0.51)
+    sleep(0.55)
     assert not timer_expired_called, "Test5: Expired called despite being cancelled"
     assert not timer_running_called, "Test5: Flapping called for some reason"
 
@@ -125,13 +125,27 @@ try:
     timers.check(test_name, "1s", function=lambda: timer_expired(), flapping_function=lambda: timer_running())
     sleep(0.5)
     timers.check(test_name, "0.5s", function=lambda: timer_expired(), flapping_function=lambda: timer_running(), reschedule=True)
-    sleep(0.51)
+    sleep(0.55)
     assert timer_running_called, "Test7: Flapping was not called"
     assert timer_expired_called, "Test7: Expired was not called"
+
+    # Test that if set the timer does not clean up itself
+    timer_expired_called = False
+    timer_running_called = False
+    timers.check(test_name, 1000, timer_expired, self_cleanup = False)
+    sleep(0.5)
+    assert timers.has_timer(test_name), "Test8: Timer not created"
+    assert not timer_expired_called, "Test8: Timer expired was called"
+    sleep(0.55)
+    assert timers.has_timer(test_name), "Test8: Timer does not exists after expiration"
+    assert timer_expired_called, "Test8: Timer expired was not called"
+    assert not timer_running_called, "Test8: Timer running was called"
+    # Remove timer
+    timers.cancel(test_name)
 
 
 except AssertionError:
     import traceback
     log.error("Exception: {}".format(traceback.format_exc()))
 else:
-    log.info("TimerMgr tests passed!")
+    log.warn("TimerMgr tests passed!")


### PR DESCRIPTION
Hi @rkoshak ,
I encountered a usage scenario, where I want to reschedule my timer within its own execution. Finding out that the timer always was cleaned up after its expiration, I thus added the possibility that it is not cleaned up to support this use case.
Furthermore, I seem to have a rather slow system, so I had to extend the "second" delay time (waiting for the exec to be over) to 0.55secs. And, as a lazy person, I did not want to change the log level I get printed out just for testing... so I propose to set level for the success message to warn.

* Added new option "self_cleanup" to check method, defaulting to True
* Changed "second" delays in tests from 0.51 to 0.55 to allow slower instances to perform tests
* Added test (no 8) for a timer not cleaning itself up
* Changed success message of timer_mgr-tests.py to log level warn, to prevent need of changing LL when running test

Looking forward to your review.
BR
Alex