### PR TITLE
[timerMgr] Name timer/scheduled jobs

### DIFF
--- a/timerMgr.js
+++ b/timerMgr.js
@@ -74,7 +74,7 @@ class TimerMgr {
 
     // timer doesn't already exist, create a new one
     else {
-      var timer = actions.ScriptExecution.createTimerWithArgument(timeout,
+      var timer = actions.ScriptExecution.createTimerWithArgument(key, timeout,
         this,
         this._notFlapping(key));
       this.timers[key] = {


### PR DESCRIPTION
This change names the created timers with the user provided `key`. 
Refers to https://github.com/openhab/openhab-core/pull/2911.

This makes debugging of errors in timers much easier, because the log message includes the name of the scheduled job/timer which failed.

Signed-off-by: Florian Hotze <florianh_dev@icloud.com>