### PR TITLE
Changed trigger to support changes in core

### DIFF
--- a/rule-templates/thingStatus/thing_status2.yaml
+++ b/rule-templates/thingStatus/thing_status2.yaml
@@ -9,13 +9,14 @@ configDescriptions:
     context: rule
     required: true
 triggers:
-  - id: "1"
-    label: GenericEventTrigger
-    description: GenericEventTrigger with filter
+  - id: "3"
+    label: A Thing Changes Status
+    description: Triggers when any Thing changes status
     configuration:
-      eventSource: ""
-      eventTopic: openhab/things/*
-      eventTypes: ThingStatusInfoChangedEvent
+      types: ThingStatusInfoChangedEvent
+      payload: ""
+      topic: openhab/things/**
+      source: ""
     type: core.GenericEventTrigger
 conditions: []
 actions:


### PR DESCRIPTION
There were changes in core to the GenericEventTrigger and GenericEventCondition: https://github.com/openhab/openhab-core/pull/3299 which required changes to this rule template's trigger. The properties changed names and the topic is now a glob instead or regex. While I was at it I updated the label and description.