### PR TITLE
Check versions of openhab-js and ohrt

### DIFF
--- a/rule-templates/debounce/debounce2.yaml
+++ b/rule-templates/debounce/debounce2.yaml
@@ -40,9 +40,9 @@ conditions:
       script: >
         console.loggerName = 'org.openhab.automation.rules_tools.Debounce';
 
-        // ~ TODO ~ TODO ~ TODO ~ TODO ~ TODO ~ TODO ~ TODO ~ TODO 
+        // ~ TODO ~ TODO ~ TODO ~ TODO ~ TODO ~ TODO ~ TODO ~ TODO
 
-        // Rework when `event` always exists and check the event.type 
+        // Rework when `event` always exists and check the event.type
 
         if(this.event !== undefined && this.event.itemName !== undefined){
           const item = items.getItem(this.event.itemName);
@@ -63,10 +63,14 @@ actions:
     configuration:
       type: application/javascript
       script: >
-        var {timerMgr} = require('openhab_rules_tools');
+        var {timerMgr, helpers} = require('openhab_rules_tools');
 
         console.loggerName = 'org.openhab.automation.rules_tools.Debounce';
 
+        //osgi.getService('org.apache.karaf.log.core.LogService').setLevel(console.loggerName, 'DEBUG');
+
+
+        helpers.validateLibraries('4.1.0', '2.0.1');
 
 
         var USAGE = "Debounce metadata should follow this format:\n"

--- a/rule-templates/ephemToD/time_state_machine.yaml
+++ b/rule-templates/ephemToD/time_state_machine.yaml
@@ -52,6 +52,9 @@ actions:
         //osgi.getService('org.apache.karaf.log.core.LogService').setLevel(console.loggerName, 'INFO');
 
 
+        helpers.validateLibraries('4.1.0', '2.0.1');
+
+
         console.debug('Starting state machine in ten seconds...');
 
 

--- a/rule-templates/expire_updater/expire_updater.yaml
+++ b/rule-templates/expire_updater/expire_updater.yaml
@@ -10,13 +10,17 @@ actions:
     configuration:
       type: application/javascript
       script: >-
+        var {helpers} = require('openhab_rules_tools');
+
         console.loggerName = 'org.openhab.automation.rules_tools.Expire';
 
         //osgi.getService('org.apache.karaf.log.core.LogService').setLevel(console.loggerName, 'INFO');
 
 
-        var allowDelete = true;
+        helpers.validateLibraries('4.1.0', '2.0.1');
 
+
+        var allowDelete = true;
 
         /**
          * value: 0h10m0s,command=ON

--- a/rule-templates/mqttEb/mqtt_eb_full.yaml
+++ b/rule-templates/mqttEb/mqtt_eb_full.yaml
@@ -62,9 +62,15 @@ actions:
     configuration:
       type: application/javascript
       script: >-
+        var {helpers} = require('openhab_rules_tools');
+
         console.loggerName = 'org.openhab.automation.rules_tools.MQTTEventBus';
 
         //osgi.getService('org.apache.karaf.log.core.LogService').setLevel(console.loggerName, 'INFO');
+
+
+        helpers.validateLibraries('4.1.0', '2.0.1');
+
 
         /**
          * Parses the event received and extracts the Item, event type, and state/command

--- a/rule-templates/presenceSim/presence_sim2.yaml
+++ b/rule-templates/presenceSim/presence_sim2.yaml
@@ -53,18 +53,19 @@ actions:
     configuration:
       type: application/javascript
       script: >-
+        var {helpers} = require('openhab_rules_tools');
+
         console.loggerName = 'org.openhab.automation.rules_tools.Presence Sim';
 
-        //osgi.getService('org.apache.karaf.log.core.LogService').setLevel(console.loggerName, 'INFO');
+        // osgi.getService('org.apache.karaf.log.core.LogService').setLevel(console.loggerName, 'DEBUG');
 
 
-        var PersistenceExtensions = Java.type('org.openhab.core.persistence.extensions.PersistenceExtensions');
+        helpers.validateLibraries('4.1.0', '2.0.1');
 
 
         items.{{simItems}}.members.forEach((i) => {
 
-        //  const hState = i.history.historicState(time.toZDT().minusDays({{days}})); // doesn't work
-          const hState = PersistenceExtensions.historicState(i.rawItem, time.toZDT().minusDays({{days}}));
+          const hState = i.history.historicState(time.toZDT().minusDays({{days}}));
           if(hState === undefined || hState === null) {
             console.warn(i.name + ' does not have a historic state for ' + '{{days}}' + ' days ago');
           }

--- a/rule-templates/thingStatus/thing_status2.yaml
+++ b/rule-templates/thingStatus/thing_status2.yaml
@@ -25,18 +25,35 @@ actions:
     configuration:
       type: application/javascript
       script: |
+        var {helpers} = require('openhab_rules_tools');
+
         console.loggerName = 'org.openhab.automation.rules_tools.Thing Status';
+
+        // osgi.getService('org.apache.karaf.log.core.LogService').setLevel(console.loggerName, 'DEBUG');
+
+
+        helpers.validateLibraries('4.1.0', '2.0.1');
+
+
         console.debug('ThingStatusInfoChangedEvent:' + event.toString());
 
         var parsed = JSON.parse(event.payload);
 
+
         var data = {};
-        data['thingID'] = event.topic.split('/')[2];;
+
+        data['thingID'] = event.topic.split('/')[2];
+
         data['thing'] = things.getThing(data['thingID']);
+
         data['oldStatus'] = parsed[1].status;
+
         data['oldDetail'] = parsed[1].statusDetail;
+
         data['newStatus'] = parsed[0].status;
+
         data['newDetail'] = parsed[0].statusDetail;
+
 
         rules.runRule("{{script}}", data, true);
     type: script.ScriptAction


### PR DESCRIPTION
Throws an error if the installed openhab-js or openhab_rules_tools versions are too old.