### PR TITLE
Added ability to query the length of a timers of a given timer with keyName.

### DIFF
--- a/timerMgr.js
+++ b/timerMgr.js
@@ -73,7 +73,8 @@ class TimerMgr {
       this.timers[key] = {
         'timer': timer,
         'flapping': flappingFunc,
-        'notFlapping': (func) ? func : this.#noop
+        'notFlapping': (func) ? func : this.#noop,
+		'when': timeout,
       };
     }
   }
@@ -84,6 +85,18 @@ class TimerMgr {
    */
   hasTimer(key) {
     return key in this.timers;
+  }
+	
+  /**
+   * @param {*} key name of the timer
+   * @returns {number} of seconds left in the timer function
+   */
+  currentTimerLength(key) {
+    if (key in this.timers) {
+		return this.timers[key]['when'].toEpochSecond() - time.toZDT().toEpochSecond();
+	}
+	  
+    return 0;
   }
 
   /**


### PR DESCRIPTION
Possible use cases: 

1) allows user to re-queue the timer at the current or a different time frame with the same or different instruction set
2) allows user to make logical decisions regarding how much longer it will take until the timer executes.

Example: An external garage door "close" timer is set for 30 minutes, but an internal garage door opens and interrupts this.  The timer can be inspected and if the time to execution is less than 10 minutes, assume the car is going to leave shortly and extend the timer to another 10 minutes from there.