### PR TITLE
fix(threshold_alert): prevent startup crash and restore alert state correctly

### DIFF
--- a/rule-templates/thresholdAlert/newThresholdAlert.yaml
+++ b/rule-templates/thresholdAlert/newThresholdAlert.yaml
@@ -1210,9 +1210,9 @@ actions:
           let state;
           if(event.newState === undefined && event.receivedState === undefined){
             console.debug('Running without event wrapper');
-            type = event.type.toString();
-            state = event.itemState.toString();
-          } 
+            type = event.type?.toString() ?? event.eventName ?? '';
+            state = event.itemState?.toString() ?? null;
+          }
           else {
             console.debug('Running with event wrapper');
             type = event.eventName;
@@ -1222,9 +1222,16 @@ actions:
             case 'ItemStateEvent':
             case 'ItemStateUpdatedEvent':
             case 'ItemStateChangedEvent':
-              console.loggerName = loggerBase+'.'+name;
-              console.debug('Processing an Item event');
-              procEvent(name, stateToValue(state));
+              if(name !== undefined && state !== null) {
+                console.loggerName = loggerBase+'.'+name;
+                console.debug('Processing an Item event');
+                procEvent(name, stateToValue(state));
+              }
+              break;
+            case 'SystemStartlevelTrigger':
+              console.info('Startup trigger in item-event path; running restore and reconcile.');
+              init(true);
+              restoreAndReconcile();
               break;
             default:
               console.info('Rule triggered without an Item event, ' + type + ' checking the rule config');

--- a/rule-templates/thresholdAlert/newThresholdAlert.yaml
+++ b/rule-templates/thresholdAlert/newThresholdAlert.yaml
@@ -808,7 +808,7 @@ actions:
         /**
          * Analyzes the rule properties and Items to verify that the config will work.
          */
-        var init = () => {
+        var init = (isStartup = false) => {
 
           console.debug( 'Rule config defaults:\n'
                        + '  Group                     - ' + group + '\n'
@@ -848,10 +848,12 @@ actions:
             });
           }
 
-          console.info('Clearing persisted alert state metadata for all group members');
-          items[group].members.forEach(item => {
-            items[item.name].removeMetadata(stateNamespace);
-          });
+          if(!isStartup) {
+            console.info('Clearing persisted alert state metadata for all group members');
+            items[group].members.forEach(item => {
+              items[item.name].removeMetadata(stateNamespace);
+            });
+          }
 
           // Inform if the threshold is UnDefType
           if(thresholdStr === 'UnDefType') {
@@ -1198,7 +1200,7 @@ actions:
 
         else if(event.eventName == "SystemStartlevelTrigger") {
           console.info('Startup trigger detected, running restore and reconcile.');
-          init();
+          init(true);
           restoreAndReconcile();
         }
 


### PR DESCRIPTION
## Summary

Two bugs that together cause all Threshold Alert rule instances to silently fail on every OpenHAB restart. Both were present before OH 5.2 and observed in production on OH 5.1.4 (openhab-js 5.18.2).

---

### Bug 1 — Crash when startup trigger lacks item context

**Symptom:** All Threshold Alert instances log `TypeError: undefined has no such function 'toString'` at startup and stop processing any events until manually re-triggered.

**Root cause:** On some OH restarts, the `SystemStartlevelTrigger` fires but `event.eventName` does not equal `"SystemStartlevelTrigger"` (observed intermittently — matched on some reboots, missed on others). The outer `else if` is skipped and the trigger falls into the item-event `else` branch. Inside that branch, `event.newState` and `event.receivedState` are both `undefined` (startup has no item state), so the _"without event wrapper"_ path runs. `event.itemState` is also `undefined` for a startup trigger, so `event.itemState.toString()` throws.

**Fix (commit 2):**
- Optional-chain `event.type?.toString()` and `event.itemState?.toString() ?? null` — neither access throws when the property is absent
- Guard `procEvent()` so it only runs when both `name` and `state` are resolved
- Add `case 'SystemStartlevelTrigger':` to the switch so any startup trigger reaching the item-event branch still runs `init(true)` + `restoreAndReconcile()`

---

### Bug 2 — init() destroys the metadata restoreAndReconcile() needs to read

**Symptom:** Even on the restarts where the crash doesn't occur, alert state is always reset to `false` after a reboot. Any Item that was in an alerted state will re-fire its alert rule after every restart (fresh notification even if the alert was already acknowledged).

**Root cause:** The startup branch calls:
```javascript
init();               // removeMetadata(stateNamespace) wipes all persisted alerted/alertState values
restoreAndReconcile(); // loadRecord() reads stateNamespace metadata — finds nothing
```
`init()` removes the exact metadata `restoreAndReconcile()` is designed to read.

**Fix (commit 1):**
- Add `isStartup = false` parameter to `init()`
- Wrap `removeMetadata` in `if(!isStartup)` — startup calls preserve the metadata so `restoreAndReconcile()` can read it correctly
- Startup branch calls `init(true)`; all other call sites are unchanged

---

## Test evidence

Log from production system (OH 5.1.4, openhab-js 5.18.2), 2026-07-02 restart — 16 Threshold Alert instances, all crashed:

```
[ERROR] [automation.rules_tools.Threshold Alert.<uid>] - TypeError: undefined has no such function "toString"
    at <eval>:1005 in <anonymous>
```

Line 1005 in the installed template corresponds exactly to `state = event.itemState.toString()`.

Same installation on 2026-06-19 and 2026-07-01: startup trigger matched `event.eventName == "SystemStartlevelTrigger"` — no crash. This confirms the intermittency is in the event wrapper, not the template logic.

## Checklist

- [x] Two independent commits — one per bug
- [x] `init(isStartup)` default is `false` — existing `ExecutionEvent` and `default:` call sites unchanged
- [x] `case 'SystemStartlevelTrigger':` in the switch uses `init(true)` for consistency
- [x] No change to rule triggers, config parameters, or external API